### PR TITLE
npm script to install typings on "npm install"

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "TypeScript logging library",
   "main": "index.js",
   "scripts": {
-    "test": "grunt ts:default jasmine; grunt clean"
+    "postinstall": "npm run typings",
+    "test": "grunt ts:default jasmine; grunt clean",
+    "typings": "tsd install"
   },
   "typescript": {
     "definition": "build/log4ts.d.ts"


### PR DESCRIPTION
I added an npm script so typings are automatically installed when npm install is run.  I tried to run npm install and then grunt test back to back and it failed because of the typings.  This change should make development setup run a little smoother.
